### PR TITLE
Typed useApolloFragment

### DIFF
--- a/packages/apollo-fragment-react/src/__tests__/index.tsx
+++ b/packages/apollo-fragment-react/src/__tests__/index.tsx
@@ -47,6 +47,11 @@ describe('ApolloFragment component', () => {
     }
   `;
 
+  type FragmentData = {
+    id: string;
+    name: string;
+  };
+
   it('Should return Fragment Data from HOC Component', () => {
     return client
       .query({
@@ -148,7 +153,7 @@ describe('ApolloFragment component', () => {
       })
       .then(() => {
         let SomeComponent = function Foo() {
-          const fragmentData = useApolloFragment(fragment, '1');
+          const fragmentData = useApolloFragment<FragmentData>(fragment, '1');
           expect(fragmentData.data.id).toEqual('1');
           expect(fragmentData.data.name).toEqual('John Smith');
           return <p>hi</p>;

--- a/packages/apollo-fragment-react/src/index.tsx
+++ b/packages/apollo-fragment-react/src/index.tsx
@@ -4,11 +4,15 @@ import { Query, graphql, useQuery } from 'react-apollo';
 import { DocumentNode } from 'graphql';
 import { getFragmentInfo, buildFragmentQuery } from 'apollo-fragment-utils';
 
-export function useApolloFragment(fragment: string, id: string) {
+type FragmentQueryData<TData = any> = {
+  getFragment?: TData;
+};
+
+export function useApolloFragment<TData = any>(fragment: string, id: string) {
   const { fragmentTypeName, fragmentName } = getFragmentInfo(fragment);
   const query: DocumentNode = buildFragmentQuery({ fragment, fragmentName });
 
-  const { data, ...rest } = useQuery(query, {
+  const { data, ...rest } = useQuery<FragmentQueryData<TData>>(query, {
     fetchPolicy: 'cache-only',
     variables: {
       id,


### PR DESCRIPTION
Allows to provide a type for fragment data in `useApolloFragment`. This provides a less clunky alternative to typing in this way:
```typescript
const { data }: { data: ConversationParticipantsFragment } = useApolloFragment(`
  fragment ConversationParticipantsFragment on Conversation {
    participants {
      id
      name
    }
  }
`, conversationId); 
```
Instead it could be this:
```typescript
const { data } = useApolloFragment<ConversationParticipantsFragment>(`
  fragment ConversationParticipantsFragment on Conversation {
    participants {
      id
      name
    }
  }
`, conversationId); 
```