### PR TITLE
Typed apollo-link-state-fragment

### DIFF
--- a/packages/apollo-link-state-fragment/tsconfig.json
+++ b/packages/apollo-link-state-fragment/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "declaration": true,
     "rootDir": "./src",
     "outDir": "lib"
   },


### PR DESCRIPTION
Includes TS type declarations in`apollo-link-state-fragment` lib folder on build.