### PR TITLE
Error message when fragment data is incomplete

### DIFF
--- a/packages/apollo-fragment-react/package.json
+++ b/packages/apollo-fragment-react/package.json
@@ -90,7 +90,8 @@
   },
   "dependencies": {
     "apollo-fragment-utils": "^0.1.3",
-    "apollo-utilities": "^1.0.12"
+    "apollo-utilities": "^1.0.12",
+    "compose-tiny": "^1.1.3"
   },
   "lint-staged": {
     "*.ts*": [

--- a/packages/apollo-fragment-react/src/__tests__/index.tsx
+++ b/packages/apollo-fragment-react/src/__tests__/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import gql from 'graphql-tag';
-import { ApolloLink, execute, Observable } from 'apollo-link';
+import { ApolloLink } from 'apollo-link';
 import { ApolloClient } from 'apollo-client';
 import { ApolloProvider } from 'react-apollo';
 import { InMemoryCache } from 'apollo-cache-inmemory';
@@ -12,19 +12,21 @@ import {
 } from '../../../apollo-link-state-fragment/src';
 import { ApolloFragment, withApolloFragment, useApolloFragment } from '../';
 
-describe('ApolloFragment component', () => {
-  let wrapper: ReactWrapper<any, any> | null;
-  beforeEach(() => {
-    jest.useRealTimers();
-  });
+type Wrapper = ReactWrapper<any, any> | null;
 
-  afterEach(() => {
-    if (wrapper) {
-      wrapper.unmount();
-      wrapper = null;
-    }
-  });
+type FragmentData = {
+  id: string;
+  name: string;
+};
 
+const fragment = `
+  fragment fragmentFields on Person {
+    id
+    name
+  }
+`;
+
+const createTestClient = () => {
   const cache = new InMemoryCache({
     cacheRedirects: {
       Query: {
@@ -35,37 +37,44 @@ describe('ApolloFragment component', () => {
 
   const local = fragmentLinkState(cache);
 
-  const client = new ApolloClient({
+  return new ApolloClient({
     cache,
     link: ApolloLink.from([local, mockLink]),
   });
+};
 
-  const fragment = `
-    fragment fragmentFields on Person {
-      id
-      name
+describe('apollo-fragment-react core behaviour', () => {
+  let wrapper: Wrapper;
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  const client = createTestClient();
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = null;
+    }
+    client.resetStore();
+  });
+
+  const PEOPLE_QUERY = gql`
+    query peeps {
+      people {
+        id
+        name
+      }
     }
   `;
-
-  type FragmentData = {
-    id: string;
-    name: string;
-  };
 
   it('Should return Fragment Data from HOC Component', () => {
     return client
       .query({
-        query: gql`
-          query peeps {
-            people {
-              id
-              name
-            }
-          }
-        `,
+        query: PEOPLE_QUERY,
       })
       .then(() => {
-        let SomeComponent = function Foo(props) {
+        let SomeComponent: React.ComponentType<any> = function Foo(props) {
           expect(props.data.id).toEqual('1');
           expect(props.data.name).toEqual('John Smith');
           return <p>hi</p>;
@@ -84,17 +93,10 @@ describe('ApolloFragment component', () => {
   it('Should return Fragment Data from HOC Component with custom "id"', () => {
     return client
       .query({
-        query: gql`
-          query peeps {
-            people {
-              id
-              name
-            }
-          }
-        `,
+        query: PEOPLE_QUERY,
       })
       .then(() => {
-        let SomeComponent = function Foo(props) {
+        let SomeComponent: React.ComponentType<any> = function Foo(props) {
           expect(props.data.id).toEqual('1');
           expect(props.data.name).toEqual('John Smith');
           return <p>hi</p>;
@@ -115,14 +117,7 @@ describe('ApolloFragment component', () => {
   it('Should return Fragment Data from Render Prop Component', () => {
     return client
       .query({
-        query: gql`
-          query peeps {
-            people {
-              id
-              name
-            }
-          }
-        `,
+        query: PEOPLE_QUERY,
       })
       .then(() => {
         wrapper = mount(
@@ -142,14 +137,7 @@ describe('ApolloFragment component', () => {
   it('Should return Fragment Data from React Hook', () => {
     return client
       .query({
-        query: gql`
-          query peeps {
-            people {
-              id
-              name
-            }
-          }
-        `,
+        query: PEOPLE_QUERY,
       })
       .then(() => {
         let SomeComponent = function Foo() {
@@ -165,5 +153,184 @@ describe('ApolloFragment component', () => {
           </ApolloProvider>,
         );
       });
+  });
+});
+
+describe('apollo-fragment-react completeness check', () => {
+  // Mock console.error to catch completeness check messages
+  const originalError = console.error;
+  let consoleOutput = [];
+  const mockedError = output => consoleOutput.push(output);
+  beforeEach(() => (console.error = mockedError));
+  afterEach(() => {
+    console.error = originalError;
+    consoleOutput = [];
+  });
+
+  let wrapper: Wrapper;
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  const client = createTestClient();
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = null;
+    }
+    client.resetStore();
+  });
+
+  const mountWithApollo = (node: React.ReactNode) =>
+    mount(<ApolloProvider client={client}>{node}</ApolloProvider>);
+
+  const INCOMPLETE_QUERY = gql`
+    query peeps {
+      people {
+        id
+      }
+    }
+  `;
+
+  const expectedErrorMessage = `
+Unable to resolve fragment fields for Person:1:
+
+  fragment fragmentFields on Person {
+    id
+    name
+  }
+
+Available data:
+{
+  "id": "1"
+}
+
+Make sure that the fields requested in the fragment are fetched by some query`;
+
+  it('Should log error when fragment data is incomplete for HOC Component', () => {
+    return client
+      .query({
+        query: INCOMPLETE_QUERY,
+      })
+      .then(() => {
+        let SomeComponent: React.ComponentType<any> = function Foo(props) {
+          expect(props.data).toBeUndefined();
+          return <p>hi</p>;
+        };
+
+        SomeComponent = withApolloFragment(fragment)(SomeComponent);
+
+        wrapper = mountWithApollo(<SomeComponent id="1" />);
+
+        expect(consoleOutput[0]).toEqual(expectedErrorMessage);
+      });
+  });
+
+  it('Should log error when fragment data is incomplete for HOC Component with custom "id"', () => {
+    return client
+      .query({
+        query: INCOMPLETE_QUERY,
+      })
+      .then(() => {
+        let SomeComponent: React.ComponentType<any> = function Foo(props) {
+          expect(props.data).toBeUndefined();
+          return <p>hi</p>;
+        };
+
+        SomeComponent = withApolloFragment(fragment, 'fragmentId')(
+          SomeComponent,
+        );
+
+        wrapper = mountWithApollo(<SomeComponent fragmentId="1" />);
+
+        expect(consoleOutput[0]).toEqual(expectedErrorMessage);
+      });
+  });
+
+  it('Should log error when fragment data is incomplete for Render Prop Component', () => {
+    return client
+      .query({
+        query: INCOMPLETE_QUERY,
+      })
+      .then(() => {
+        wrapper = mountWithApollo(
+          <ApolloFragment fragment={fragment} id="1">
+            {(result: any) => {
+              expect(result.data).toEqual({});
+              return <p>hi</p>;
+            }}
+          </ApolloFragment>,
+        );
+        expect(consoleOutput[0]).toEqual(expectedErrorMessage);
+      });
+  });
+
+  it('Should log error when fragment data is incomplete for hook', () => {
+    return client
+      .query({
+        query: INCOMPLETE_QUERY,
+      })
+      .then(() => {
+        let SomeComponent = function Foo() {
+          const fragmentData = useApolloFragment<FragmentData>(fragment, '1');
+          expect(fragmentData.data).toBeUndefined();
+          return <p>hi</p>;
+        };
+
+        wrapper = mountWithApollo(<SomeComponent />);
+
+        expect(consoleOutput[0]).toEqual(expectedErrorMessage);
+      });
+  });
+
+  it('Should NOT log error when fragment data is empty for HOC Component', () => {
+    let SomeComponent: React.ComponentType<any> = function Foo(props) {
+      expect(props.data).toBeUndefined();
+      return <p>hi</p>;
+    };
+
+    SomeComponent = withApolloFragment(fragment)(SomeComponent);
+
+    wrapper = mountWithApollo(<SomeComponent id="1" />);
+
+    expect(consoleOutput).toHaveLength(0);
+  });
+
+  it('Should NOT log error when fragment data is empty for HOC Component with custom "id"', () => {
+    let SomeComponent: React.ComponentType<any> = function Foo(props) {
+      expect(props.data).toBeUndefined();
+      return <p>hi</p>;
+    };
+
+    SomeComponent = withApolloFragment(fragment, 'fragmentId')(SomeComponent);
+
+    wrapper = mountWithApollo(<SomeComponent fragmentId="1" />);
+
+    expect(consoleOutput).toHaveLength(0);
+  });
+
+  it('Should NOT log error when fragment data is empty for Render Prop Component', () => {
+    wrapper = mountWithApollo(
+      <ApolloFragment fragment={fragment} id="1">
+        {(result: any) => {
+          expect(result.data).toEqual({});
+          return <p>hi</p>;
+        }}
+      </ApolloFragment>,
+    );
+    expect(consoleOutput).toHaveLength(0);
+  });
+
+  it('Should NOT log error when fragment data is empty for hook', () => {
+    let SomeComponent = function Foo() {
+      const fragmentData = useApolloFragment<FragmentData>(fragment, '1');
+      expect(fragmentData.data).toBeUndefined();
+      return <p>hi</p>;
+    };
+
+    wrapper = mountWithApollo(<SomeComponent />);
+
+    expect(consoleOutput).toHaveLength(0);
   });
 });


### PR DESCRIPTION
### Summary
This PR makes `apollo-fragment-react` report when the required fragment fields cannot be fulfilled with the data currently in cache. This can help to see if some query does not fetch fields needed for the fragment.

### Details
There is quite a common problem, when we're trying to use a fragment with fields that are not fetched by any query:
```javascript
import { useApolloFragment } from 'apollo-fragment-react'

const userAvatarFragment = `
  fragment UserAvatarFragment on User {
    avatar
    name
  }
`

function UserAvatar({ userId }) {
  const { data } = useApolloFragment(userAvatarFragment, userId)
  return (
    <img src={data && data.avatar} alt={data && data.name} />
  )
}

// Note that we are not requesting "name"
const INCOMPLETE_QUERY = gql`
  query getUsers {
      id
      avatar
  }
`

function UsersAvatars() {
  const { data } = useQuery(INCOMPLETE_QUERY)

  return (data && data.getUsers || []).map((user) => (
    <UserAvatar key={user.id} userId={user.id} />
  ))
}
```
Since we are not fetching `name` field, the `data` returned by `useApolloFragment` will be `undefined`.
We need to add `name` to our `INCOMPLETE_QUERY` definition to fix it, but we currently do not let the developer know if they need to do this.

This PR makes `useApolloFragment` hook, `ApolloFragment` component and `withApolloFragment` HOC log an error when the fragment data is incomplete. For the example above, it would report something like this:
```
Unable to resolve fragment fields for User:958366ba-59de-44d4-89ce-86d0d12101bb:

  fragment UserAvatarFragment on User {
    avatar
    name
  }

Available data:
{
  "id": "958366ba-59de-44d4-89ce-86d0d12101bb",
  "avatar": "https://placekitten.com/200/200"
}

Make sure that the fields requested in the fragment are fetched by some query
```

This message will only appear **if Apollo cache already has some data for the fragment**.  This allows us not to spam error messages if the query has not completed yet.