### PR TITLE
Support fragment ASTs

### DIFF
--- a/packages/apollo-fragment-react/src/__tests__/index.tsx
+++ b/packages/apollo-fragment-react/src/__tests__/index.tsx
@@ -102,9 +102,10 @@ describe('apollo-fragment-react core behaviour', () => {
           return <p>hi</p>;
         };
 
-        SomeComponent = withApolloFragment(fragment, 'fragmentId')(
-          SomeComponent,
-        );
+        SomeComponent = withApolloFragment(
+          fragment,
+          'fragmentId',
+        )(SomeComponent);
 
         wrapper = mount(
           <ApolloProvider client={client}>
@@ -142,6 +143,30 @@ describe('apollo-fragment-react core behaviour', () => {
       .then(() => {
         let SomeComponent = function Foo() {
           const fragmentData = useApolloFragment<FragmentData>(fragment, '1');
+          expect(fragmentData.data.id).toEqual('1');
+          expect(fragmentData.data.name).toEqual('John Smith');
+          return <p>hi</p>;
+        };
+
+        wrapper = mount(
+          <ApolloProvider client={client}>
+            <SomeComponent />
+          </ApolloProvider>,
+        );
+      });
+  });
+
+  it('Should return Fragment Data from React Hook for fragment AST', () => {
+    return client
+      .query({
+        query: PEOPLE_QUERY,
+      })
+      .then(() => {
+        let SomeComponent = function Foo() {
+          const fragmentData = useApolloFragment<FragmentData>(
+            gql(fragment),
+            '1',
+          );
           expect(fragmentData.data.id).toEqual('1');
           expect(fragmentData.data.name).toEqual('John Smith');
           return <p>hi</p>;
@@ -238,9 +263,10 @@ Make sure that the fields requested in the fragment are fetched by some query`;
           return <p>hi</p>;
         };
 
-        SomeComponent = withApolloFragment(fragment, 'fragmentId')(
-          SomeComponent,
-        );
+        SomeComponent = withApolloFragment(
+          fragment,
+          'fragmentId',
+        )(SomeComponent);
 
         wrapper = mountWithApollo(<SomeComponent fragmentId="1" />);
 
@@ -274,6 +300,27 @@ Make sure that the fields requested in the fragment are fetched by some query`;
       .then(() => {
         let SomeComponent = function Foo() {
           const fragmentData = useApolloFragment<FragmentData>(fragment, '1');
+          expect(fragmentData.data).toBeUndefined();
+          return <p>hi</p>;
+        };
+
+        wrapper = mountWithApollo(<SomeComponent />);
+
+        expect(consoleOutput[0]).toEqual(expectedErrorMessage);
+      });
+  });
+
+  it('Should log error when fragment data is incomplete for hook for fragment AST', () => {
+    return client
+      .query({
+        query: INCOMPLETE_QUERY,
+      })
+      .then(() => {
+        let SomeComponent = function Foo() {
+          const fragmentData = useApolloFragment<FragmentData>(
+            gql(fragment),
+            '1',
+          );
           expect(fragmentData.data).toBeUndefined();
           return <p>hi</p>;
         };

--- a/packages/apollo-fragment-utils/package.json
+++ b/packages/apollo-fragment-utils/package.json
@@ -17,19 +17,16 @@
   },
   "homepage": "https://github.com/abhiaiyer91/apollo-fragment#readme",
   "scripts": {
-    "build:browser":
-      "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-link --i apollo-utilities --i graphql-anywhere && npm run minify:browser",
+    "build:browser": "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-link --i apollo-utilities --i graphql-anywhere && npm run minify:browser",
     "build": "tsc -p .",
     "bundle": "rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "filesize": "npm run build && npm run build:browser && bundlesize",
     "prelint": "npm run lint-fix",
-    "lint-fix":
-      "prettier --trailing-comma all --single-quote --write \"src/**/*.{j,t}s*\"",
+    "lint-fix": "prettier --trailing-comma all --single-quote --write \"src/**/*.{j,t}s*\"",
     "lint": "tslint --type-check -p tsconfig.json -c tslint.json src/*.ts",
     "lint-staged": "lint-staged",
-    "minify:browser":
-      "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
+    "minify:browser": "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
     "postbuild": "npm run bundle",
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
@@ -56,6 +53,7 @@
     "danger": "1.2.0",
     "graphql": "0.11.7",
     "graphql-tag": "2.5.0",
+    "jest": "21.2.1",
     "lint-staged": "4.3.0",
     "pre-commit": "1.2.2",
     "prettier": "1.7.4",
@@ -71,6 +69,19 @@
   "dependencies": {
     "apollo-utilities": "^1.0.12"
   },
+  "jest": {
+    "mapCoverage": true,
+    "transform": {
+      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    },
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "json"
+    ]
+  },
   "lint-staged": {
     "*.ts*": [
       "prettier --trailing-comma all --single-quote --write",
@@ -80,7 +91,10 @@
       "prettier --trailing-comma all --single-quote --write",
       "git add"
     ],
-    "*.json*": ["prettier --write", "git add"]
+    "*.json*": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "pre-commit": "lint-staged"
 }

--- a/packages/apollo-fragment-utils/src/__tests__/index.test.ts
+++ b/packages/apollo-fragment-utils/src/__tests__/index.test.ts
@@ -1,0 +1,79 @@
+import gql from 'graphql-tag';
+import { getFragmentInfo, buildFragmentQuery } from '../';
+
+describe('getFragmentInfo', () => {
+  it('should return correct fragment name and typename for string fragments', () => {
+    const fragment = `
+            fragment testFragment on Person {
+                name
+                avatar
+            }
+        `;
+
+    const fragmentInfo = getFragmentInfo(fragment);
+
+    expect(fragmentInfo.fragmentName).toBe('testFragment');
+    expect(fragmentInfo.fragmentTypeName).toBe('Person');
+  });
+
+  it('should return correct fragment name and typename for fragments parsed into GraphQL AST', () => {
+    const fragment = gql`
+      fragment testFragment on Person {
+        name
+        avatar
+      }
+    `;
+
+    const fragmentInfo = getFragmentInfo(fragment);
+
+    expect(fragmentInfo.fragmentName).toBe('testFragment');
+    expect(fragmentInfo.fragmentTypeName).toBe('Person');
+  });
+});
+
+describe('buildFragmentQuery', () => {
+  const expectedQuery = gql`
+    query getFragment($id: ID, $__typename: String) {
+      getFragment(id: $id, __typename: $__typename) @client {
+        ...testFragment
+      }
+    }
+
+    fragment testFragment on Person {
+      name
+      avatar
+    }
+  `;
+
+  it('should return a valid query based on a string fragment', () => {
+    const fragment = `
+            fragment testFragment on Person {
+                name
+                avatar
+            }
+        `;
+
+    const fragmentQuery = buildFragmentQuery({
+      fragment,
+      fragmentName: `testFragment`,
+    });
+
+    expect(fragmentQuery).toEqual(expectedQuery);
+  });
+
+  it('should return a valid query based on a fragment parsed into GraphQL AST', () => {
+    const fragment = gql`
+      fragment testFragment on Person {
+        name
+        avatar
+      }
+    `;
+
+    const fragmentQuery = buildFragmentQuery({
+      fragment,
+      fragmentName: `testFragment`,
+    });
+
+    expect(fragmentQuery).toEqual(expectedQuery);
+  });
+});

--- a/packages/apollo-fragment-utils/src/index.ts
+++ b/packages/apollo-fragment-utils/src/index.ts
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag';
 import { DocumentNode } from 'graphql';
 
-export function getFragmentInfo(fragment: string) {
-  const fragmentAST = gql(fragment);
+export function getFragmentInfo(fragment: string | DocumentNode) {
+  const fragmentAST = typeof fragment === `string` ? gql(fragment) : fragment;
   const fragmentDefinitions =
     fragmentAST.definitions && fragmentAST.definitions[0];
   const fragmentName = fragmentDefinitions && fragmentDefinitions.name.value;
@@ -16,7 +16,7 @@ export function getFragmentInfo(fragment: string) {
 }
 
 export type buildFragmentQueryType = {
-  fragment: string;
+  fragment: string | DocumentNode;
   fragmentName: string;
 };
 


### PR DESCRIPTION
As per #9 and its thread, adds support for passing fragment AST in `apollo-fragment-react`:
```javascript
const fragment = gql`
  fragment fragmentFields on Person {
    id
    name
  }
`;

return useApolloFragment(fragment, '1234')
```