### PR TITLE
feat: add apollo-fragment-react-codegen package

### DIFF
--- a/packages/apollo-fragment-react-codegen/.npmignore
+++ b/packages/apollo-fragment-react-codegen/.npmignore
@@ -1,0 +1,9 @@
+dist/tests/
+src/
+tests/
+.travis.yml
+tsconfig.json
+tslint.json
+typings.d.ts
+example/
+__tests__/

--- a/packages/apollo-fragment-react-codegen/README.md
+++ b/packages/apollo-fragment-react-codegen/README.md
@@ -1,0 +1,99 @@
+# Apollo Fragment React Codegen
+This package contains a plugin for [GraphQL Code Generator](https://graphql-code-generator.com/) 
+that allows to generate React hooks with corresponding TypeScript types 
+based on `useApolloFragment` from `apollo-fragment-react` and GraphQL fragments defined in your app.
+
+## Setup
+This package **requires** [TypeScript React Apollo](https://graphql-code-generator.com/docs/plugins/typescript-react-apollo) plugin 
+to be installed and setup to generate fragment documents and types.
+
+First, install the package:
+```bash
+yarn add -D apollo-fragment-react-codegen
+```
+Then register the plugin in GraphQL Code Generator config (`codegen.yml` by default):
+```yml
+generates:
+path/to/file.ts:
+ plugins:
+   - typescript
+   - typescript-operations
+   - typescript-react-apollo
+   - apollo-fragment-react-codegen
+ config:
+   withHooks: true
+```
+Now, whenever you run your codegen script, it will also generate React hooks based on existing fragment definitions 
+which you then can use in your code instead of `useApolloFragment`.
+
+## Usage
+Suppose you have some existing code to read user name and avatar from Apollo Client cache using `useApolloFragment`:
+```typescript
+// UserAvatar.tsx
+import gql from 'graphql-tag'
+import { useApolloFragment } from 'apollo-fragment-react'
+import { User } from 'src/generated.ts'
+
+const userAvatarAndNameFragment = gql`
+    fragment userAvatarAndNameFragment on User {
+        name
+        avatarUrl
+    }
+`
+
+type FragmentData = Pick<User, 'name' | 'avatarUrl'>
+
+export function UserAvatar(userId: string) {
+    const { data: userData } = useApolloFragment<FragmentData>(userId)
+
+    if (!userData) {
+        return null
+    }
+
+    return <img src={userData.avatarUrl} alt={`${userData.name} avatar`} />
+}
+```
+To leverage GraphQL codegen, let's move the fragment definiton into a `.graphql` file:
+```graphql
+# fragments.graphql
+
+fragment userAvatarAndName on User {
+    name
+    avatarUrl
+}
+```
+and make sure that we include this file in the codegen configuration:
+```yml
+documents:
+  - "src/**/*.graphql"
+  # OR
+  # - "src/**/fragments.graphql"
+```
+Now, when we run the codegen script, the generated file should also include something like this:
+```typescript
+export function useUserAvatarAndNameFragment(id: string) {
+  return useApolloFragment<UserAvatarAndNameFragment>(
+    UserAvatarAndNameFragmentDoc,
+    id
+  )
+}
+export type UserAvatarAndNameFragmentHookResult = ReturnType<
+  typeof useUserAvatarAndNameFragment
+>
+```
+Next we can update our `UserAvatar` component:
+```typescript
+// UserAvatar.tsx
+import { useUserAvatarAndNameFragment } from 'src/generated.ts'
+
+export function UserAvatar(userId: string) {
+    const { data: userData } = useUserAvatarAndNameFragment(userId)
+
+    if (!userData) {
+        return null
+    }
+
+    return <img src={userData.avatarUrl} alt={`${userData.name} avatar`} />
+}
+```
+`useUserAvatarAndNameFragment` is just a wrapper around `useApolloFragment` which reduce the amount of boilerplate and also properly types the return value.

--- a/packages/apollo-fragment-react-codegen/package.json
+++ b/packages/apollo-fragment-react-codegen/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "apollo-fragment-react-codegen",
+  "version": "0.7.0",
+  "description": "A plugin for graphql-code-generator that allows to generate React hooks based on fragment definitions",
+  "author": "Aleksei Ustiuzhanin <elanhant@gmail.com>",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "module": "lib/index.esm.js",
+  "typings": "lib/index.d.ts",
+  "typescript": {
+    "definition": "lib/index.d.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/abhiaiyer91/apollo-fragment.git"
+  },
+  "bugs": {
+    "url": "https://github.com/abhiaiyer91/apollo-fragment/issues"
+  },
+  "homepage": "https://github.com/abhiaiyer91/apollo-fragment#readme",
+  "scripts": {
+    "build": "tsc -p .",
+    "clean": "rimraf lib/* && rimraf coverage/*",
+    "prelint": "npm run lint-fix",
+    "lint-fix": "prettier --trailing-comma all --single-quote --write \"src/**/*.{j,t}s*\"",
+    "lint": "tslint --type-check -p tsconfig.json -c tslint.json src/*.ts",
+    "lint-staged": "lint-staged",
+    "prebuild": "npm run clean",
+    "prepublishOnly": "npm run clean && npm run build",
+    "test": "jest",
+    "coverage": "npm run lint && jest --coverage",
+    "watch": "trap 'kill -9 %1' SIGINT; tsc -w -p ."
+  },
+  "peerDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0",
+    "graphql-tag": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/graphql": "^14.5.0",
+    "@types/jest": "22.1.x",
+    "codecov": "3.0.0",
+    "danger": "1.2.0",
+    "graphql": "^15.1.0",
+    "graphql-tag": "^2.0.0",
+    "jest": "21.2.1",
+    "lint-staged": "4.3.0",
+    "pre-commit": "1.2.2",
+    "prettier": "1.7.4",
+    "rimraf": "2.6.1",
+    "ts-jest": "21.1.4",
+    "tslint": "5.8.0",
+    "typescript": "^2.9.2"
+  },
+  "jest": {
+    "mapCoverage": true,
+    "transform": {
+      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    },
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "json"
+    ]
+  },
+  "dependencies": {
+    "@graphql-codegen/plugin-helpers": "^1.15.4",
+    "@graphql-codegen/visitor-plugin-common": "^1.15.4",
+    "pascal-case": "^3.1.1"
+  },
+  "lint-staged": {
+    "*.ts*": [
+      "prettier --trailing-comma all --single-quote --write",
+      "git add"
+    ],
+    "*.js*": [
+      "prettier --trailing-comma all --single-quote --write",
+      "git add"
+    ],
+    "*.json*": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "pre-commit": "lint-staged"
+}

--- a/packages/apollo-fragment-react-codegen/src/config.ts
+++ b/packages/apollo-fragment-react-codegen/src/config.ts
@@ -1,0 +1,34 @@
+import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-common';
+
+/**
+ * @description This plugin generates hooks based on apollo-fragment-react with TypeScript typings.
+ *
+ * It requires typescript-react-apollo to be setup to generate fragment documents.
+ */
+export interface ApolloFragmentReactRawPluginConfig
+  extends RawClientSideBasePluginConfig {
+  /**
+   * @description Customize the package where apollo-fragment-react lib is loaded from.
+   * @default "apollo-fragment-react"
+   */
+  apolloFragmentReactImportFrom?: string;
+  /**
+   * @description Allows you to enable/disable the generation of docblocks in generated code.
+   * Some IDE's (like VSCode) add extra inline information with docblocks, you can disable this feature if your preferred IDE does not.
+   * @default true
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *    - typescript-react-apollo
+   *    - apollo-fragment-react-codegen
+   *  config:
+   *    addDocBlocks: true
+   * ```
+   */
+  addDocBlocks?: boolean;
+}

--- a/packages/apollo-fragment-react-codegen/src/index.ts
+++ b/packages/apollo-fragment-react-codegen/src/index.ts
@@ -1,0 +1,65 @@
+import {
+  Types,
+  PluginValidateFn,
+  PluginFunction,
+} from '@graphql-codegen/plugin-helpers';
+import {
+  GraphQLSchema,
+  concatAST,
+  Kind,
+  FragmentDefinitionNode,
+} from 'graphql';
+import { LoadedFragment } from '@graphql-codegen/visitor-plugin-common';
+import { ApolloFragmentReactVisitor } from './visitor';
+import { extname } from 'path';
+import { ApolloFragmentReactRawPluginConfig } from './config';
+
+export const plugin: PluginFunction<
+  ApolloFragmentReactRawPluginConfig,
+  Types.ComplexPluginOutput
+> = (
+  schema: GraphQLSchema,
+  documents: Types.DocumentFile[],
+  config: ApolloFragmentReactRawPluginConfig,
+) => {
+  const allAst = concatAST(documents.map(v => v.document));
+
+  const allFragments: LoadedFragment[] = [
+    ...(allAst.definitions.filter(
+      d => d.kind === Kind.FRAGMENT_DEFINITION,
+    ) as FragmentDefinitionNode[]).map(fragmentDef => ({
+      node: fragmentDef,
+      name: fragmentDef.name.value,
+      onType: fragmentDef.typeCondition.name.value,
+      isExternal: false,
+    })),
+    ...(config.externalFragments || []),
+  ];
+
+  const visitor = new ApolloFragmentReactVisitor(
+    schema,
+    allFragments,
+    config,
+    documents,
+  );
+
+  return {
+    prepend: visitor.getImports(),
+    content: visitor.fragments,
+  };
+};
+
+export const validate: PluginValidateFn<any> = async (
+  _schema: GraphQLSchema,
+  _documents: Types.DocumentFile[],
+  _config: ApolloFragmentReactRawPluginConfig,
+  outputFile: string,
+) => {
+  if (extname(outputFile) !== '.ts' && extname(outputFile) !== '.tsx') {
+    throw new Error(
+      `Plugin "apollo-fragment-react-codegen" requires extension to be ".ts" or ".tsx"!`,
+    );
+  }
+};
+
+export { ApolloFragmentReactVisitor };

--- a/packages/apollo-fragment-react-codegen/src/visitor.ts
+++ b/packages/apollo-fragment-react-codegen/src/visitor.ts
@@ -1,0 +1,105 @@
+import {
+  ClientSideBaseVisitor,
+  ClientSideBasePluginConfig,
+  getConfigValue,
+  LoadedFragment,
+} from '@graphql-codegen/visitor-plugin-common';
+import { ApolloFragmentReactRawPluginConfig } from './config';
+import autoBind from 'auto-bind';
+import { GraphQLSchema, FragmentDefinitionNode } from 'graphql';
+import { Types } from '@graphql-codegen/plugin-helpers';
+import { pascalCase } from 'pascal-case';
+
+export interface ReactApolloPluginConfig extends ClientSideBasePluginConfig {
+  apolloFragmentReactImportFrom: string;
+  withResultType: boolean;
+  addDocBlocks: boolean;
+}
+
+export class ApolloFragmentReactVisitor extends ClientSideBaseVisitor<
+  ApolloFragmentReactRawPluginConfig,
+  ReactApolloPluginConfig
+> {
+  constructor(
+    schema: GraphQLSchema,
+    fragments: LoadedFragment[],
+    rawConfig: ApolloFragmentReactRawPluginConfig,
+    documents: Types.DocumentFile[],
+  ) {
+    super(schema, fragments, rawConfig, {
+      apolloFragmentReactImportFrom: getConfigValue(
+        rawConfig.apolloFragmentReactImportFrom,
+        `apollo-fragment-react`,
+      ),
+      addDocBlocks: getConfigValue(rawConfig.addDocBlocks, true),
+    });
+
+    this._documents = documents;
+
+    autoBind(this);
+  }
+
+  public getImports(): string[] {
+    const baseImports = super.getImports();
+
+    return [...baseImports, this.getApolloFragmentReactImport()];
+  }
+
+  protected _generateFragment(fragmentDocument: FragmentDefinitionNode) {
+    const hooks = this._buildHooks(fragmentDocument);
+
+    return [hooks, ''].filter(a => a).join('\n');
+  }
+
+  private getApolloFragmentReactImport(): string {
+    return `import { useApolloFragment } from '${this.config.apolloFragmentReactImportFrom}';`;
+  }
+
+  private _buildHooksJSDoc(operationName: string): string {
+    return `
+  /**
+   * __use${operationName}__
+   * To read a fragment data from Apollo Cache, call \`use${operationName}\` and pass it the ID of the cached object.
+   * When your component renders, \`use${operationName}\` returns an object from Apollo Client cache that contains data property
+   * you can use to render your UI.
+   *
+   * @param id a string representing the ID of the cached object that will be passed into the useApolloFragment
+   *
+   * @example
+   * const { data } = use${operationName}('fragment-id');
+   */`;
+  }
+
+  private _buildHooks(fragment: FragmentDefinitionNode): string {
+    const suffix = this._getHookSuffix(fragment.name.value);
+    const operationName: string = this.convertName(fragment.name.value, {
+      suffix,
+      useTypesPrefix: false,
+    });
+
+    const hookFns = [
+      `export function use${operationName}(id: string) {
+          return useApolloFragment<${this.getFragmentName(
+            fragment,
+          )}>(${this.getFragmentVariableName(fragment)}, id);
+        }`,
+    ];
+
+    if (this.config.addDocBlocks) {
+      hookFns.unshift(this._buildHooksJSDoc(operationName));
+    }
+
+    const hookResults = [
+      `export type ${operationName}HookResult = ReturnType<typeof use${operationName}>;`,
+    ];
+
+    return [...hookFns, ...hookResults].join('\n');
+  }
+
+  private _getHookSuffix(name: string) {
+    if (name.includes('Fragment')) {
+      return '';
+    }
+    return pascalCase(`fragment`);
+  }
+}

--- a/packages/apollo-fragment-react-codegen/tsconfig.json
+++ b/packages/apollo-fragment-react-codegen/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "outDir": "lib",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "importHelpers": true,
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "target": "esnext",
+    "lib": ["es6", "esnext", "es2015", "dom"],
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "sourceMap": true,
+    "declaration": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["./src"]
+}

--- a/packages/apollo-fragment-react-codegen/tslint.json
+++ b/packages/apollo-fragment-react-codegen/tslint.json
@@ -1,0 +1,65 @@
+{
+  "rules": {
+    "ban": false,
+    "class-name": true,
+    "eofline": true,
+    "forin": true,
+    "interface-name": [true, "never-prefix"],
+    "jsdoc-format": true,
+    "label-position": true,
+    "member-access": true,
+    "member-ordering": [
+      true,
+      {
+        "order": [
+          "static-field",
+          "instance-field",
+          "constructor",
+          "public-instance-method",
+          "protected-instance-method",
+          "private-instance-method"
+        ]
+      }
+    ],
+    "no-any": false,
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-conditional-assignment": true,
+    "no-consecutive-blank-lines": false,
+    "no-console": [true, "log", "debug", "info", "time", "timeEnd", "trace"],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-variable": true,
+    "no-empty": true,
+    "no-eval": true,
+    "no-inferrable-types": false,
+    "no-internal-module": true,
+    "no-null-keyword": false,
+    "no-require-imports": false,
+    "no-shadowed-variable": true,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": true,
+    "no-unused-expression": true,
+    "no-var-keyword": true,
+    "no-var-requires": true,
+    "object-literal-sort-keys": false,
+    "radix": true,
+    "switch-default": true,
+    "triple-equals": [true, "allow-null-check"],
+    "typedef": [
+      false,
+      "call-signature",
+      "parameter",
+      "arrow-parameter",
+      "property-declaration",
+      "variable-declaration",
+      "member-variable-declaration"
+    ],
+    "variable-name": [
+      true,
+      "check-format",
+      "allow-leading-underscore",
+      "ban-keywords"
+    ]
+  }
+}


### PR DESCRIPTION
Adds a new package, `apollo-fragment-react-codegen`, which contains a plugin for [GraphQL Code Generator](https://graphql-code-generator.com/)  to generate React hooks based on fragment definitions (heavily based on the existing  [TypeScript React Apollo](https://graphql-code-generator.com/docs/plugins/typescript-react-apollo) plugin.

Here's the new package's readme:
# Apollo Fragment React Codegen
This package contains a plugin for [GraphQL Code Generator](https://graphql-code-generator.com/) 
that allows to generate React hooks with corresponding TypeScript types 
based on `useApolloFragment` from `apollo-fragment-react` and GraphQL fragments defined in your app.

## Setup
This package **requires** [TypeScript React Apollo](https://graphql-code-generator.com/docs/plugins/typescript-react-apollo) plugin 
to be installed and setup to generate fragment documents and types.

First, install the package:
```bash
yarn add -D apollo-fragment-react-codegen
```
Then register the plugin in GraphQL Code Generator config (`codegen.yml` by default):
```yml
generates:
path/to/file.ts:
 plugins:
   - typescript
   - typescript-operations
   - typescript-react-apollo
   - apollo-fragment-react-codegen
 config:
   withHooks: true
```
Now, whenever you run your codegen script, it will also generate React hooks based on existing fragment definitions 
which you then can use in your code instead of `useApolloFragment`.

## Usage
Suppose you have some existing code to read user name and avatar from Apollo Client cache using `useApolloFragment`:
```typescript
// UserAvatar.tsx
import gql from 'graphql-tag'
import { useApolloFragment } from 'apollo-fragment-react'
import { User } from 'src/generated.ts'

const userAvatarAndNameFragment = gql`
    fragment userAvatarAndNameFragment on User {
        name
        avatarUrl
    }
`

type FragmentData = Pick<User, 'name' | 'avatarUrl'>

export function UserAvatar(userId: string) {
    const { data: userData } = useApolloFragment<FragmentData>(userId)

    if (!userData) {
        return null
    }

    return <img src={userData.avatarUrl} alt={`${userData.name} avatar`} />
}
```
To leverage GraphQL codegen, let's move the fragment definiton into a `.graphql` file:
```graphql
# fragments.graphql

fragment userAvatarAndName on User {
    name
    avatarUrl
}
```
and make sure that we include this file in the codegen configuration:
```yml
documents:
  - "src/**/*.graphql"
  # OR
  # - "src/**/fragments.graphql"
```
Now, when we run the codegen script, the generated file should also include something like this:
```typescript
export function useUserAvatarAndNameFragment(id: string) {
  return useApolloFragment<UserAvatarAndNameFragment>(
    UserAvatarAndNameFragmentDoc,
    id
  )
}
export type UserAvatarAndNameFragmentHookResult = ReturnType<
  typeof useUserAvatarAndNameFragment
>
```
Next we can update our `UserAvatar` component:
```typescript
// UserAvatar.tsx
import { useUserAvatarAndNameFragment } from 'src/generated.ts'

export function UserAvatar(userId: string) {
    const { data: userData } = useUserAvatarAndNameFragment(userId)

    if (!userData) {
        return null
    }

    return <img src={userData.avatarUrl} alt={`${userData.name} avatar`} />
}
```
`useUserAvatarAndNameFragment` is just a wrapper around `useApolloFragment` which reduce the amount of boilerplate and also properly types the return value. 